### PR TITLE
Updated Prerequisites section in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Python SDK for Upstox API
 
 The official Python library for communicating with the Upstox APIs.
@@ -29,10 +30,14 @@ Python 2.x or 3.x
 Also, you need the following modules:
 
 * `future`
-* `websocket_client`
+* `websocket_client (version 0.40.0)`
 * `requests` 
 
 The modules can also be installed using `pip`
+The specific version of websocket_client is needed for proper functioning of live feed.
+To install version 0.40.0 of websocket client use pip as follows:
+
+`pip install websocket_client=0.40.0`
 
 ## Getting started with API
 


### PR DESCRIPTION
Added the specific version of websocket_client required to run Upstox live feed. The lack of this information is causing a lot of inconvenience to the people using Upstox API. Adding the specific version of websocket_client in the docs is important.