### PR TITLE
fix: add missing plotly, pandas, numpy to Streamlit requirements

### DIFF
--- a/interactive_examples/requirements.txt
+++ b/interactive_examples/requirements.txt
@@ -1,2 +1,6 @@
 upstox-python-sdk
 plotext
+streamlit
+plotly
+pandas
+numpy


### PR DESCRIPTION
streamlit_app.py imports numpy, pandas, plotly.express, and plotly.graph_objects at the top level, but requirements.txt only listed upstox-python-sdk and plotext — causing the Streamlit Cloud deployment to fail on startup with ModuleNotFoundError before any user-facing code runs.

Added the four missing packages:
- streamlit (explicit pin, good practice for Cloud deployments)
- plotly (candlestick + volume charts, options visualisations)
- pandas (dataframes throughout all examples)
- numpy (maths helpers in options analytics and historical analysis)