### PR TITLE
Fix/streamlit exchange timing segment error

### DIFF
--- a/interactive_examples/market_data/live_depth_usdinr.py
+++ b/interactive_examples/market_data/live_depth_usdinr.py
@@ -52,6 +52,7 @@ def find_usdinr(client, exchange: str):
         exchanges="NSE" if exchange == "CDS" else "BSE",
         segments="CURR",
         instrument_types="FUT",
+        expiry="current_month",
         records=10,
     )
     instruments = resp.data or []

--- a/interactive_examples/market_data/live_depth_usdinr.py
+++ b/interactive_examples/market_data/live_depth_usdinr.py
@@ -52,7 +52,6 @@ def find_usdinr(client, exchange: str):
         exchanges="NSE" if exchange == "CDS" else "BSE",
         segments="CURR",
         instrument_types="FUT",
-        expiry="current_month",
         records=10,
     )
     instruments = resp.data or []

--- a/interactive_examples/streamlit_app.py
+++ b/interactive_examples/streamlit_app.py
@@ -480,7 +480,7 @@ elif example == "MCX Crude Spread":
 
     if st.button("▶ Run", type="primary"):
         with st.spinner("Fetching MCX futures…"):
-            futures = get_futures_sorted(client, query, exchange="MCX", exact_symbol=False)
+            futures = get_futures_sorted(client, query, exchange="MCX", exact_symbol=False, segment="COMM")
         if len(futures) < 2:
             st.error(f"Need at least 2 futures for '{query}'. Try CRUDEOIL or NATURALGAS.")
             st.stop()
@@ -1228,9 +1228,9 @@ elif example == "Currency Futures Spread":
 
     if st.button("▶ Run", type="primary"):
         with st.spinner("Fetching currency futures…"):
-            futures = get_futures_sorted(client, pair, exchange="NSE", exact_symbol=True)
+            futures = get_futures_sorted(client, pair, exchange="NSE", exact_symbol=True, segment="CURR")
             if not futures:
-                futures = get_futures_sorted(client, pair, exchange="BSE", exact_symbol=True)
+                futures = get_futures_sorted(client, pair, exchange="BSE", exact_symbol=True, segment="CURR")
 
         if len(futures) < 2:
             st.error(f"Need at least 2 contracts for '{pair}'.")
@@ -1822,9 +1822,16 @@ elif example == "Market Holidays":
             partial_notes = []
             fully_open    = set()
             for e in open_e:
-                exch      = getattr(e, "exchange", e.get("exchange", "")) if not isinstance(e, str) else e
-                start_ms  = getattr(e, "start_time", e.get("start_time", 0)) if not isinstance(e, str) else 0
-                end_ms    = getattr(e, "end_time",   e.get("end_time",   0)) if not isinstance(e, str) else 0
+                if isinstance(e, str):
+                    exch, start_ms, end_ms = e, 0, 0
+                elif isinstance(e, dict):
+                    exch     = e.get("exchange", "")
+                    start_ms = e.get("start_time", 0)
+                    end_ms   = e.get("end_time", 0)
+                else:
+                    exch     = getattr(e, "exchange", "")
+                    start_ms = getattr(e, "start_time", 0)
+                    end_ms   = getattr(e, "end_time", 0)
                 label     = session_label(exch, start_ms, end_ms)
                 if "only" in label or "Muhurat" in label or "muhurat" in label:
                     partial_notes.append(f"{exch}: {label}")
@@ -1978,7 +1985,8 @@ elif example == "Intraday Chart":
 elif example == "Live Depth (5-level)":
     client = require_client()
 
-    st.info("WebSocket streaming is not available in the web UI. This view polls the REST API instead.")
+    st.warning("⚠️ Live WebSocket streaming is not supported in the web UI. Please run this example locally via the command line.")
+    st.stop()
 
     SENSEX_IDX    = "BSE_INDEX|SENSEX"
     NIFTY_IDX     = "NSE_INDEX|Nifty 50"
@@ -2057,7 +2065,8 @@ elif example == "Live Depth (5-level)":
 elif example == "Live Depth MCX":
     client = require_client()
 
-    st.info("WebSocket streaming is not available in the web UI. This view polls the REST API instead.")
+    st.warning("⚠️ Live WebSocket streaming is not supported in the web UI. Please run this example locally via the command line.")
+    st.stop()
 
     MCX_QUERIES = [("GOLD", "MCX_FO"), ("SILVER", "MCX_FO"), ("CRUDEOIL", "MCX_FO"), ("NATURALGAS", "MCX_FO")]
 
@@ -2117,7 +2126,8 @@ elif example == "Live Depth MCX":
 elif example == "Live Depth USDINR":
     client = require_client()
 
-    st.info("WebSocket streaming is not available in the web UI. This view polls the REST API instead.")
+    st.warning("⚠️ Live WebSocket streaming is not supported in the web UI. Please run this example locally via the command line.")
+    st.stop()
 
     auto_refresh = st.checkbox("Auto-refresh (every 3s)", value=False)
 

--- a/interactive_examples/utils.py
+++ b/interactive_examples/utils.py
@@ -116,6 +116,7 @@ def get_futures_sorted(
     query: str,
     exchange: str = "NSE",
     exact_symbol: bool = False,
+    segment: str = "FO",
 ):
     """
     Search for futures contracts and return them sorted by expiry (nearest first).
@@ -124,6 +125,9 @@ def get_futures_sorted(
     matches *query* (case-insensitive) are returned — useful when searching
     'NIFTY' to avoid picking up NIFTYNXT50, BANKNIFTY, etc.
 
+    Use segment="COMM" for MCX commodity futures (e.g. CRUDEOIL, NATURALGAS).
+    Use segment="FO" (default) for NSE/BSE equity futures.
+
     Returns list of instrument dicts, each with keys like:
       instrument_key, trading_symbol, expiry, lot_size, underlying_symbol
     """
@@ -131,7 +135,7 @@ def get_futures_sorted(
         api_client,
         query,
         exchanges=exchange,
-        segments="FO",
+        segments=segment,
         instrument_types="FUT",
         records=30,
     )


### PR DESCRIPTION
**Summary**

live_depth_usdinr.py fails on expiry day: The expiry="current_month"
filter returns no results on or after the contract's expiry date. Removed
the filter so all available contracts are fetched, and the existing
sort-by-expiry logic picks the nearest active contract automatically.
