### PR TITLE
revomed expiry from live_depth_usdinr in interactive examples

### DIFF
--- a/interactive_examples/market_data/live_depth_usdinr.py
+++ b/interactive_examples/market_data/live_depth_usdinr.py
@@ -52,7 +52,6 @@ def find_usdinr(client, exchange: str):
         exchanges="NSE" if exchange == "CDS" else "BSE",
         segments="CURR",
         instrument_types="FUT",
-        expiry="current_month",
         records=10,
     )
     instruments = resp.data or []


### PR DESCRIPTION
**Summary**

**live_depth_usdinr.py** fails on expiry day: The expiry="current_month"
filter returns no results on or after the contract's expiry date. Removed
the filter so all available contracts are fetched, and the existing
sort-by-expiry logic picks the nearest active contract automatically.