### PR TITLE
ci: publish wheel alongside sdist on PyPI release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build only, do not upload"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    name: Build sdist + wheel and publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Check distributions
+        run: python -m twine check dist/*
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        if: ${{ github.event_name == 'release' && inputs.dry_run != 'true' }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload --non-interactive dist/*


### PR DESCRIPTION
## Summary
Fixes #127 — build and publish a pure-Python wheel (.whl) to PyPI on every GitHub Release, alongside the existing sdist.

## Problem
\`upstox-python-sdk\` currently only ships an sdist to PyPI. \`pip install upstox-python-sdk\` therefore runs setuptools locally on every install, which is slower, requires a working build toolchain on minimal base images, and can subtly diverge across platforms.

## Change
New workflow \`.github/workflows/publish.yml\`:
- Runs on \`release: published\` (and \`workflow_dispatch\` for testing).
- Builds sdist + wheel via \`python -m build\` (PEP 517).
- Runs \`twine check\` on the artifacts to catch metadata issues before upload.
- Uploads both files as workflow artifacts for inspection.
- Publishes to PyPI via \`TWINE_PASSWORD=\${{ secrets.PYPI_API_TOKEN }}\` (API token auth).
- The \`workflow_dispatch\` path accepts \`dry_run: true\` so maintainers can validate the build without touching PyPI.

No source code changes required — this package is pure Python and already uses \`setuptools\` via \`setup.py\`, so \`python -m build\` produces a valid universal wheel out of the box.

## One-time setup on maintainer side
1. Generate a PyPI API token scoped to the \`upstox-python-sdk\` project.
2. Add it as a repository secret named \`PYPI_API_TOKEN\`.

After that, every published GitHub Release will ship both formats automatically.

## Test plan
- [x] \`python -m build\` locally produces \`upstox_python_sdk-<version>-py3-none-any.whl\` and the sdist.
- [x] \`python -m twine check dist/*\` passes.
- [x] \`workflow_dispatch\` with \`dry_run=true\` uploads artifacts without publishing.
- [ ] First real release after merge publishes both sdist and wheel to PyPI (to be verified by maintainer).