### PR TITLE
replace removed Styler.applymap with Styler.map

### DIFF
--- a/interactive_examples/streamlit_app.py
+++ b/interactive_examples/streamlit_app.py
@@ -1500,7 +1500,7 @@ elif example == "Sector Index Comparison":
             c = "green" if val > 0 else ("red" if val < 0 else "grey")
             return f"color: {c}; font-weight: bold"
 
-        st.dataframe(df.style.applymap(color_chg, subset=["Change", "Change %"]),
+        st.dataframe(df.style.map(color_chg, subset=["Change", "Change %"]),
                      use_container_width=True)
 
 
@@ -1799,7 +1799,7 @@ elif example == "Market Status":
             if "PRE" in str(val).upper():    return "color: #f39c12; font-weight: bold"
             return ""
 
-        st.dataframe(df.style.applymap(colour_status, subset=["Status"]),
+        st.dataframe(df.style.map(colour_status, subset=["Status"]),
                      use_container_width=True)
 
 


### PR DESCRIPTION
## Fix: `Styler.applymap` removed in pandas 3.0

  ### Problem
  Opening the **Portfolio & Streaming → Sector Index Comparison** example in the interactive Streamlit app crashes with:

  ```
  AttributeError: 'Styler' object has no attribute 'applymap'
    File "interactive_examples/streamlit_app.py", line 1503, in <module>
      st.dataframe(df.style.applymap(color_chg, subset=["Change", "Change %"]), ...)
  ```

  `pandas.io.formats.style.Styler.applymap` was **deprecated in pandas 2.1.0** and **removed in pandas 3.0**. Since
  `interactive_examples/requirements.txt` pins no upper bound on pandas, users on a current pandas pick up 3.x and hit the
  crash.

  ### Fix
  Rename the two elementwise-styling calls from `.style.applymap(...)` to `.style.map(...)`. `Styler.map` is the direct
  replacement with an identical signature (`func`, `subset=`), so this is a pure rename with no behavior change.

  Affected lines in `interactive_examples/streamlit_app.py`:
  - **Line 1503** — Sector Index Comparison (color Change / Change % cells)
  - **Line 1802** — status coloring example