### PR TITLE
 Handle invalid/expired tokens gracefully in the Streamlit example app

### DIFF
--- a/interactive_examples/README.md
+++ b/interactive_examples/README.md
@@ -27,8 +27,8 @@ A Streamlit web app wraps every example with a UI — paste your token and run:
 Or run locally:
 
 ```bash
-git clone https://github.com/upstox/python-examples
-cd python-examples
+git clone https://github.com/upstox/upstox-python.git
+cd interactive_examples
 pip install -r requirements.txt
 streamlit run streamlit_app.py
 ```

--- a/interactive_examples/streamlit_app.py
+++ b/interactive_examples/streamlit_app.py
@@ -19,12 +19,16 @@ import streamlit as st
 
 sys.path.insert(0, os.path.dirname(__file__))
 import upstox_client
+from upstox_client.rest import ApiException
 from utils import (
+    check_token,
     get_api_client,
     get_futures_sorted,
     get_full_quote,
     get_historical_candles,
     get_ltp,
+    is_invalid_token_error,
+    parse_api_error,
     search_instrument,
 )
 
@@ -138,11 +142,57 @@ with st.sidebar:
 
 # ── Shared helpers ────────────────────────────────────────────────────────────
 
+def show_api_error(exc: ApiException):
+    """Render an Upstox ApiException as a friendly Streamlit message."""
+    status, code, message = parse_api_error(exc)
+    if is_invalid_token_error(exc):
+        st.error(
+            "🔒 **Invalid or expired token.**\n\n"
+            "The token in the sidebar was rejected by Upstox "
+            f"({code or 'UDAPI100050'}). Please paste a valid analytics or "
+            "daily access token and try again.\n\n"
+            "- Analytics tokens: Upstox Developer Apps → **Analytics** tab (1-year, read-only).\n"
+            "- Daily access tokens expire every day — regenerate via the OAuth login flow."
+        )
+    else:
+        st.error(
+            f"❌ **Upstox API error {status or ''}** {('· ' + code) if code else ''}\n\n"
+            f"{message or exc.reason or 'The request failed. Please try again.'}"
+        )
+
+
+# ── Global API-error interceptor ──────────────────────────────────────────────
+# Every SDK call — whether through a utils helper or a direct upstox_client.XxxApi
+# call — funnels through ApiClient.call_api. Wrapping it once turns any ApiException
+# (e.g. an invalid/expired token) into a friendly message + graceful stop for ALL
+# examples, instead of a raw traceback. Installed once per process; the sentinel
+# guard stops Streamlit's per-interaction reruns from stacking wrappers.
+if not getattr(upstox_client.ApiClient, "_friendly_errors_installed", False):
+    _orig_call_api = upstox_client.ApiClient.call_api
+
+    def _call_api_with_friendly_errors(self, *args, **kwargs):
+        try:
+            return _orig_call_api(self, *args, **kwargs)
+        except ApiException as exc:
+            show_api_error(exc)
+            st.stop()
+
+    upstox_client.ApiClient.call_api = _call_api_with_friendly_errors
+    upstox_client.ApiClient._friendly_errors_installed = True
+
+
 def require_client():
     if not token:
         st.info("👈 Paste your Upstox token in the sidebar to get started.")
         st.stop()
-    return get_api_client(token)
+    client = get_api_client(token)
+    # Validate the token once per distinct token value (cached to avoid an API ping
+    # on every rerun) so an invalid token is reported the moment an example loads,
+    # not only after clicking Run. The interceptor above handles the failure path.
+    if st.session_state.get("_validated_token") != token:
+        check_token(client)
+        st.session_state["_validated_token"] = token
+    return client
 
 
 def lv(obj):

--- a/interactive_examples/utils.py
+++ b/interactive_examples/utils.py
@@ -6,9 +6,11 @@ Analytics tokens are 1-year, read-only tokens that skip the OAuth flow — ideal
 for data pipelines and dashboards.
 """
 
+import json
 import sys
 from datetime import date
 import upstox_client
+from upstox_client.rest import ApiException
 
 
 def get_api_client(token: str) -> upstox_client.ApiClient:
@@ -16,6 +18,49 @@ def get_api_client(token: str) -> upstox_client.ApiClient:
     config = upstox_client.Configuration()
     config.access_token = token
     return upstox_client.ApiClient(config)
+
+
+def parse_api_error(exc: ApiException):
+    """
+    Pull the useful bits out of an Upstox ApiException.
+
+    The SDK raises ApiException with a JSON body like:
+      {"status":"error","errors":[{"errorCode":"UDAPI100050",
+                                    "message":"Invalid token used to access API"}]}
+
+    Returns (status, error_code, message) — any of which may be None if the
+    body could not be parsed.
+    """
+    status = getattr(exc, "status", None)
+    code = message = None
+    body = getattr(exc, "body", None)
+    if body:
+        try:
+            errors = json.loads(body).get("errors") or []
+            if errors:
+                err = errors[0]
+                code = err.get("errorCode") or err.get("error_code")
+                message = err.get("message")
+        except (ValueError, TypeError, AttributeError):
+            pass
+    return status, code, message
+
+
+def is_invalid_token_error(exc: ApiException) -> bool:
+    """True if the exception indicates an invalid/expired access token."""
+    status, code, _ = parse_api_error(exc)
+    return status == 401 or code == "UDAPI100050"
+
+
+def check_token(api_client: upstox_client.ApiClient) -> None:
+    """
+    Verify the token by pinging a lightweight authenticated endpoint.
+
+    Uses instrument search — the same call every example relies on, so it is
+    guaranteed to be in-scope for both daily access and analytics tokens.
+    Raises ApiException on failure (e.g. 401 for an invalid token).
+    """
+    upstox_client.InstrumentsApi(api_client).search_instrument("RELIANCE", records=1)
 
 
 def search_instrument(api_client: upstox_client.ApiClient, query: str, **kwargs):


### PR DESCRIPTION
Invalid/expired tokens crashed every example with a raw `ApiException`
  traceback (redacted on Streamlit Cloud). This shows a clear in-app message
  instead — app-wide, by wrapping the single chokepoint `ApiClient.call_api`.

  **Changes**
  - `interactive_examples/utils.py` — add `parse_api_error()`,
    `is_invalid_token_error()`, and `check_token()` (lightweight auth ping).
  - `interactive_examples/streamlit_app.py` — add `show_api_error()`, a global
    `ApiClient.call_api` interceptor (friendly `st.error` + `st.stop()` on any
    `ApiException`), and upfront token validation in `require_client()`.