### PR TITLE
Derive COMM segment for MCX futures search and default exact-match off

### DIFF
--- a/interactive_examples/streamlit_app.py
+++ b/interactive_examples/streamlit_app.py
@@ -324,7 +324,7 @@ elif example == "Search Futures":
     c1, c2, c3 = st.columns([2, 1, 1])
     query = c1.text_input("Search query", value="NIFTY")
     exch  = c2.selectbox("Exchange", ["NSE", "BSE", "MCX"])
-    exact = c3.checkbox("Exact underlying match", value=True,
+    exact = c3.checkbox("Exact underlying match", value=False,
                         help="Filter strictly by underlying_symbol to avoid e.g. NIFTYNXT50 when searching NIFTY")
 
     if st.button("🔍 Search", type="primary"):

--- a/interactive_examples/utils.py
+++ b/interactive_examples/utils.py
@@ -161,7 +161,7 @@ def get_futures_sorted(
     query: str,
     exchange: str = "NSE",
     exact_symbol: bool = False,
-    segment: str = "FO",
+    segment: str = None,
 ):
     """
     Search for futures contracts and return them sorted by expiry (nearest first).
@@ -170,12 +170,16 @@ def get_futures_sorted(
     matches *query* (case-insensitive) are returned — useful when searching
     'NIFTY' to avoid picking up NIFTYNXT50, BANKNIFTY, etc.
 
-    Use segment="COMM" for MCX commodity futures (e.g. CRUDEOIL, NATURALGAS).
-    Use segment="FO" (default) for NSE/BSE equity futures.
+    The segment is derived from *exchange* when not given explicitly:
+    MCX commodities (e.g. CRUDEOIL, NATURALGAS) use "COMM"; NSE/BSE equity
+    futures use "FO". Pass segment explicitly to override (e.g. "CURR" for
+    currency futures on NSE/BSE).
 
     Returns list of instrument dicts, each with keys like:
       instrument_key, trading_symbol, expiry, lot_size, underlying_symbol
     """
+    if segment is None:
+        segment = "COMM" if exchange.upper() == "MCX" else "FO"
     response = search_instrument(
         api_client,
         query,


### PR DESCRIPTION
Problem

  On the Search Futures page of the Streamlit interactive examples, searching for MCX commodities
  (e.g. CRUDE) returned "No futures found", even though the equivalent API call works:

  curl --location
  'https://api.upstox.com/v2/instruments/search?query=CRUDE&exchanges=MCX&segments=FUT' \
    --header 'Accept: application/json' \
    --header 'Authorization: Bearer <YOUR_ACCESS_TOKEN>'

  Root cause

  get_futures_sorted() defaulted to segment="FO". The Search Futures and Futures OI Buildup pages
  both offer MCX in the exchange dropdown but never passed a segment, so MCX searches ran against FO
  and returned nothing. MCX commodities live under the COMM segment.

  Changes

  - interactive_examples/utils.py — get_futures_sorted() now derives the segment from the exchange
  when not passed explicitly: MCX → COMM, otherwise FO. Explicit segment values (e.g. CURR, COMM)
  are still honored, so existing callers are unaffected. This fixes both affected pages (Search
  Futures and Futures OI Buildup) at the source rather than per call site.
  - interactive_examples/streamlit_app.py — "Exact underlying match" checkbox on the Search Futures
  page now defaults to False, so partial queries like CRUDE return CRUDEOIL contracts instead of
  being filtered out.

  Testing

  - Validated segment derivation logic (MCX → COMM, NSE/BSE → FO) and syntax.
  - Manual verification: CRUDE on MCX now returns CRUDEOIL futures contracts.