### PR TITLE
fix: pin starlette<1.4.0 to resolve Streamlit Cloud GZip middleware crash

### DIFF
--- a/interactive_examples/requirements.txt
+++ b/interactive_examples/requirements.txt
@@ -1,6 +1,11 @@
 upstox-python-sdk
 plotext
 streamlit
+# Pin Starlette below 1.4.0: Streamlit's GZip middleware subclasses
+# Starlette's GZipResponder and calls __init__ without the
+# thread_minimum_size kwarg that 1.4.0 made required, which 500s every
+# request on Streamlit Cloud. Streamlit doesn't cap Starlette itself.
+starlette<1.4.0
 plotly
 pandas
 numpy


### PR DESCRIPTION
The interactive examples app crashed on Streamlit Cloud with a repeating traceback on every
  request and health check:
  TypeError: GZipResponder.__init__() missing 1 required keyword-only argument:
  'thread_minimum_size'

  Root cause

  interactive_examples/requirements.txt pinned nothing, so uv resolved the newest transitive
  dependencies — including Starlette 1.4.0. Streamlit 1.61.0's _MediaAwareGZipResponder calls
  Starlette's GZipResponder.__init__ without the thread_minimum_size kwarg that Starlette 1.4.0 made
  required. Streamlit doesn't cap Starlette in its own metadata, so nothing prevented the
  incompatible resolution, and every request 500s inside the GZip middleware.

  Change

  - interactive_examples/requirements.txt — pinned starlette<1.4.0 so Streamlit Cloud resolves a
  Starlette whose GZipResponder signature still matches Streamlit's call.

  Notes

  The pin is a targeted cap on the Starlette version the deploy log proved broken. If a redeploy
  still fails, the more robust fallback is to pin the full streamlit + starlette version matrix to a
  known-good combination.